### PR TITLE
Fix lazy loading issue in email templates

### DIFF
--- a/app/Casts/EmailDataCast.php
+++ b/app/Casts/EmailDataCast.php
@@ -58,7 +58,9 @@ class EmailDataCast implements CastsAttributes
         }
 
         if (isset($data['order'])) {
-            $return['order'] = ShopOrder::query()->findOrFail($data['order']['id']);
+            $return['order'] = ShopOrder::query()
+                ->with(['items.product', 'items.variant', 'payment', 'refunds'])
+                ->findOrFail($data['order']['id']);
         }
 
         if (isset($data['notifiable'])) {


### PR DESCRIPTION
Added eager loading for shop order relationships (items.product, items.variant, payment, refunds) in EmailDataCast to prevent lazy loading errors when rendering email templates.

Fixes #314