### PR TITLE
Fix OpenGraph image updated_at timestamp not being updated

### DIFF
--- a/app/Jobs/OpenGraphImages/CreateBlogIndexPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateBlogIndexPageOpenGraphImageJob.php
@@ -39,5 +39,6 @@ class CreateBlogIndexPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateCollectionIndexPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateCollectionIndexPageOpenGraphImageJob.php
@@ -39,5 +39,6 @@ class CreateCollectionIndexPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateEateryAppPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateEateryAppPageOpenGraphImageJob.php
@@ -60,5 +60,6 @@ class CreateEateryAppPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateEateryIndexPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateEateryIndexPageOpenGraphImageJob.php
@@ -60,5 +60,6 @@ class CreateEateryIndexPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateEateryMapPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateEateryMapPageOpenGraphImageJob.php
@@ -60,5 +60,6 @@ class CreateEateryMapPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateHomePageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateHomePageOpenGraphImageJob.php
@@ -43,5 +43,6 @@ class CreateHomePageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateRecipeIndexPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateRecipeIndexPageOpenGraphImageJob.php
@@ -39,5 +39,6 @@ class CreateRecipeIndexPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }

--- a/app/Jobs/OpenGraphImages/CreateShopIndexPageOpenGraphImageJob.php
+++ b/app/Jobs/OpenGraphImages/CreateShopIndexPageOpenGraphImageJob.php
@@ -54,5 +54,6 @@ class CreateShopIndexPageOpenGraphImageJob implements ShouldQueue
 
         $openGraphModel->clearMediaCollection();
         $openGraphModel->addMediaFromBase64($base64Image)->usingFileName('og-image.png')->toMediaCollection();
+        $openGraphModel->touch();
     }
 }


### PR DESCRIPTION
When OpenGraph image jobs run, they need to update the parent OpenGraphImage model's updated_at timestamp so that the 24-hour check in GetOpenGraphImageForRouteAction can properly detect newly generated images.

Added touch() call after adding media in all 8 job classes

Fixes #318