### PR TITLE
Add Facebook and Instagram URL fields to eateries

### DIFF
--- a/app/Console/Commands/OneTime/MigrateEateriesSocialUrlsCommand.php
+++ b/app/Console/Commands/OneTime/MigrateEateriesSocialUrlsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\OneTime;
+
+use App\Models\EatingOut\Eatery;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\progress;
+
+class MigrateEateriesSocialUrlsCommand extends Command
+{
+    protected $signature = 'one-time:migrate-eateries-social-urls';
+
+    protected int $facebookMigrated = 0;
+
+    protected int $instagramMigrated = 0;
+
+    public function handle(): void
+    {
+        $eateries = Eatery::withoutGlobalScopes()
+            ->whereNotNull('website')
+            ->where('website', '!=', '')
+            ->get();
+
+        if ($eateries->isEmpty()) {
+            $this->line('No eateries with website URLs found.');
+            $this->line('Facebook URLs migrated: 0');
+            $this->line('Instagram URLs migrated: 0');
+
+            return;
+        }
+
+        progress(
+            label: 'Migrating social URLs',
+            steps: $eateries,
+            callback: $this->processEatery(...),
+        );
+
+        $this->line("Facebook URLs migrated: {$this->facebookMigrated}");
+        $this->line("Instagram URLs migrated: {$this->instagramMigrated}");
+    }
+
+    protected function processEatery(Eatery $eatery): void
+    {
+        $website = $eatery->website;
+
+        if ($this->isFacebookUrl($website)) {
+            $eatery->updateQuietly(['facebook_url' => $website, 'website' => null]);
+
+            ++$this->facebookMigrated;
+
+            return;
+        }
+
+        if ($this->isInstagramUrl($website)) {
+            $eatery->updateQuietly(['instagram_url' => $website, 'website' => null]);
+
+            ++$this->instagramMigrated;
+        }
+    }
+
+    protected function isFacebookUrl(string $url): bool
+    {
+        return str_contains($url, 'facebook.com') || str_contains($url, 'fb.com');
+    }
+
+    protected function isInstagramUrl(string $url): bool
+    {
+        return str_contains($url, 'instagram.com');
+    }
+}

--- a/app/Http/Api/V1/Resources/EatingOut/EateryDetailsResource.php
+++ b/app/Http/Api/V1/Resources/EatingOut/EateryDetailsResource.php
@@ -39,6 +39,8 @@ class EateryDetailsResource extends JsonResource
             'type' => $this->type?->name,
             'cuisine' => $this->cuisine?->cuisine,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'menu' => $this->gf_menu_link,
             'restaurants' => $this->restaurants->map(fn (EateryAttractionRestaurant $restaurant): array => [
                 'name' => $restaurant->restaurant_name,

--- a/app/Http/Api/V1/Resources/EatingOut/EaterySuggestEditResource.php
+++ b/app/Http/Api/V1/Resources/EatingOut/EaterySuggestEditResource.php
@@ -21,6 +21,8 @@ class EaterySuggestEditResource extends JsonResource
         return [
             'address' => $this->address,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'gf_menu_link' => $this->gf_menu_link,
             'phone' => $this->phone,
             'type_id' => $this->type_id,

--- a/app/Http/Api/V1/Resources/EatingOut/EaterySummaryResource.php
+++ b/app/Http/Api/V1/Resources/EatingOut/EaterySummaryResource.php
@@ -24,6 +24,8 @@ class EaterySummaryResource extends JsonResource
             'type' => $this->type?->name,
             'cuisine' => $this->cuisine?->cuisine,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'restaurants' => $this->restaurants->map(fn (EateryAttractionRestaurant $restaurant): array => [
                 'name' => $restaurant->restaurant_name,
                 'info' => $restaurant->info,

--- a/app/Http/Api/V1/Resources/EatingOut/NationwideEateryResource.php
+++ b/app/Http/Api/V1/Resources/EatingOut/NationwideEateryResource.php
@@ -19,6 +19,8 @@ class NationwideEateryResource extends JsonResource
             'id' => $this->id,
             'info' => $this->type_id === EateryType::ATTRACTION->value ? $this->restaurants->first()?->info : $this->info,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'type' => EateryType::from((int) $this->type_id)->name(),
             'average_rating' => $this->average_rating,
             'number_of_ratings' => $this->reviews->count(),

--- a/app/Nova/Resources/EatingOut/Eateries.php
+++ b/app/Nova/Resources/EatingOut/Eateries.php
@@ -213,6 +213,10 @@ class Eateries extends Resource
                     ->hideFromIndex(),
 
                 URL::make('GF Menu Link')->fullWidth()->nullable()->rules(['max:255'])->hideFromIndex(),
+
+                URL::make('Facebook URL', 'facebook_url')->fullWidth()->nullable()->rules(['max:255'])->hideFromIndex(),
+
+                URL::make('Instagram URL', 'instagram_url')->fullWidth()->nullable()->rules(['max:255'])->hideFromIndex(),
             ]),
 
             Panel::make('Details', [

--- a/app/Resources/EatingOut/EateryAppResource.php
+++ b/app/Resources/EatingOut/EateryAppResource.php
@@ -64,6 +64,8 @@ class EateryAppResource extends JsonResource
             'address' => $branch->address ?? $this->address,
             'phone' => $this->phone,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'gf_menu_link' => $this->gf_menu_link,
             'lat' => $branch->lat ?? $this->lat,
             'lng' => $branch->lng ?? $this->lng,

--- a/app/Resources/EatingOut/EateryBrowseDetailsResource.php
+++ b/app/Resources/EatingOut/EateryBrowseDetailsResource.php
@@ -24,6 +24,8 @@ class EateryBrowseDetailsResource extends JsonResource
             'type' => $this->type?->name,
             'cuisine' => $this->cuisine?->cuisine,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'restaurants' => $this->restaurants->map(fn (EateryAttractionRestaurant $restaurant): array => [
                 'name' => $restaurant->restaurant_name,
                 'info' => $restaurant->info,

--- a/app/Resources/EatingOut/EateryDetailsResource.php
+++ b/app/Resources/EatingOut/EateryDetailsResource.php
@@ -59,6 +59,8 @@ class EateryDetailsResource extends JsonResource
             'type' => $this->type?->name,
             'cuisine' => $this->cuisine?->cuisine,
             'website' => $this->website,
+            'facebook_url' => $this->facebook_url,
+            'instagram_url' => $this->instagram_url,
             'menu' => $this->gf_menu_link,
             'restaurants' => $this->restaurants->map(fn (EateryAttractionRestaurant $restaurant): array => [
                 'name' => $restaurant->restaurant_name,

--- a/database/migrations/2026_04_20_195026_add_social_url_columns_to_wheretoeat_table.php
+++ b/database/migrations/2026_04_20_195026_add_social_url_columns_to_wheretoeat_table.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('wheretoeat', function (Blueprint $table): void {
+            $table->string('facebook_url')->nullable()->after('website');
+            $table->string('instagram_url')->nullable()->after('facebook_url');
+        });
+    }
+
+};

--- a/resources/js/Components/PageSpecific/EatingOut/Browse/PlaceDetails.vue
+++ b/resources/js/Components/PageSpecific/EatingOut/Browse/PlaceDetails.vue
@@ -10,6 +10,9 @@ import { LinkIcon } from '@heroicons/vue/24/solid';
 import { pluralise } from '@/helpers';
 import { Link } from '@inertiajs/vue3';
 import Icon from '@/Components/Icon.vue';
+import FacebookIcon from '@/Icons/FacebookIcon.vue';
+import InstagramIcon from '@/Icons/InstagramIcon.vue';
+import type { Component } from 'vue';
 
 const props = withDefaults(
   defineProps<{
@@ -54,6 +57,36 @@ const closeSidebar = () => {
 
   isLoading.value = true;
 };
+
+const socialLink = computed(
+  (): { url: string; label: string; icon: Component } | null => {
+    if (placeDetails.value?.website) {
+      return {
+        url: placeDetails.value.website,
+        label: 'Visit Website',
+        icon: LinkIcon as Component,
+      };
+    }
+
+    if (placeDetails.value?.facebook_url) {
+      return {
+        url: placeDetails.value.facebook_url,
+        label: 'Facebook',
+        icon: FacebookIcon as Component,
+      };
+    }
+
+    if (placeDetails.value?.instagram_url) {
+      return {
+        url: placeDetails.value.instagram_url,
+        label: 'Instagram',
+        icon: InstagramIcon as Component,
+      };
+    }
+
+    return null;
+  },
+);
 
 const icon = computed((): string => {
   if (placeDetails.value?.type === 'Hotel / B&B') {
@@ -130,14 +163,17 @@ const icon = computed((): string => {
 
                 <div>
                   <a
-                    v-if="placeDetails.website"
+                    v-if="socialLink"
                     class="mt-2 inline-flex items-center rounded-full bg-primary-light/90 px-3 py-1 text-xs leading-none font-semibold text-black transition-all ease-in-out hover:bg-primary-light/100"
-                    :href="placeDetails.website"
+                    :href="socialLink.url"
                     target="_blank"
                   >
-                    <LinkIcon class="mr-2 h-4 w-4" />
+                    <component
+                      :is="socialLink.icon"
+                      class="!mr-2 !h-4 !w-4"
+                    />
 
-                    Visit Website
+                    {{ socialLink.label }}
                   </a>
                 </div>
               </div>

--- a/resources/js/Components/PageSpecific/EatingOut/Details/EateryHeaderLinks.vue
+++ b/resources/js/Components/PageSpecific/EatingOut/Details/EateryHeaderLinks.vue
@@ -9,6 +9,8 @@ import {
   MapIcon,
   WalletIcon,
 } from '@heroicons/vue/24/solid';
+import FacebookIcon from '@/Icons/FacebookIcon.vue';
+import InstagramIcon from '@/Icons/InstagramIcon.vue';
 import DynamicMap from '@/Components/Maps/DynamicMap.vue';
 import Modal from '@/Components/Overlays/Modal.vue';
 import EateryOpeningTimesModal from '@/Components/PageSpecific/EatingOut/Details/Modals/EateryOpeningTimesModal.vue';
@@ -84,6 +86,34 @@ const openText = computed(() => {
       >
         <LinkIcon class="h-4 w-4" />
         <span>Website</span>
+      </a>
+    </li>
+
+    <li
+      v-if="eatery.facebook_url"
+      class="rounded-sm bg-primary-light/25 px-3 py-1 leading-none"
+    >
+      <a
+        class="flex items-center space-x-3 text-sm font-semibold text-grey transition-all ease-in-out hover:text-black"
+        :href="eatery.facebook_url"
+        target="_blank"
+      >
+        <FacebookIcon class="!h-4 !w-4" />
+        <span>Facebook</span>
+      </a>
+    </li>
+
+    <li
+      v-if="eatery.instagram_url"
+      class="rounded-sm bg-primary-light/25 px-3 py-1 leading-none"
+    >
+      <a
+        class="flex items-center space-x-3 text-sm font-semibold text-grey transition-all ease-in-out hover:text-black"
+        :href="eatery.instagram_url"
+        target="_blank"
+      >
+        <InstagramIcon class="!h-4 !w-4" />
+        <span>Instagram</span>
       </a>
     </li>
 

--- a/resources/js/Pages/EatingOut/CoeliacSanctuaryOnTheGo.vue
+++ b/resources/js/Pages/EatingOut/CoeliacSanctuaryOnTheGo.vue
@@ -82,7 +82,7 @@ defineProps<{ image: string }>();
 
       <a
         title="Apple App Store"
-        href="https://apps.apple.com/us/app/coeliac-sanctuary-on-the-go/id1608694621"
+        href="https://apps.apple.com/gb/app/gluten-free-on-the-go/id1608694621"
         target="_blank"
         class="flex flex-col items-center space-y-2 rounded-sm bg-linear-to-br from-primary/30 to-primary-light/30 p-2 sm:h-full sm:max-w-1/2 lg:p-4"
       >

--- a/resources/js/types/EateryTypes.d.ts
+++ b/resources/js/types/EateryTypes.d.ts
@@ -58,6 +58,8 @@ export type NationwideEatery = {
   type: string;
   venue_type?: string;
   website?: string;
+  facebook_url?: string;
+  instagram_url?: string;
   is_fully_gf: boolean;
 };
 
@@ -132,6 +134,8 @@ export type TownEatery = Eatery & {
   venue_type?: string;
   cuisine?: string;
   website?: string;
+  facebook_url?: string;
+  instagram_url?: string;
   restaurants: {
     name?: string;
     info: string;

--- a/tests/Unit/Console/Commands/MigrateEateriesSocialUrlsCommandTest.php
+++ b/tests/Unit/Console/Commands/MigrateEateriesSocialUrlsCommandTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Console\Commands\OneTime\MigrateEateriesSocialUrlsCommand;
+use App\Models\EatingOut\Eatery;
+use Database\Seeders\EateryScaffoldingSeeder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MigrateEateriesSocialUrlsCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(EateryScaffoldingSeeder::class);
+    }
+
+    #[Test]
+    public function itMigratesFacebookUrlToFacebookUrlColumnAndClearsWebsite(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => 'https://www.facebook.com/someeatery',
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame('https://www.facebook.com/someeatery', $eatery->facebook_url);
+        $this->assertNull($eatery->website);
+        $this->assertNull($eatery->instagram_url);
+    }
+
+    #[Test]
+    public function itMigratesFbComShortUrlToFacebookUrlColumnAndClearsWebsite(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => 'https://fb.com/someeatery',
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame('https://fb.com/someeatery', $eatery->facebook_url);
+        $this->assertNull($eatery->website);
+        $this->assertNull($eatery->instagram_url);
+    }
+
+    #[Test]
+    public function itMigratesInstagramUrlToInstagramUrlColumnAndClearsWebsite(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => 'https://www.instagram.com/someeatery',
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame('https://www.instagram.com/someeatery', $eatery->instagram_url);
+        $this->assertNull($eatery->website);
+        $this->assertNull($eatery->facebook_url);
+    }
+
+    #[Test]
+    public function itLeavesNonSocialWebsiteUntouched(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => 'https://www.someeatery.co.uk',
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame('https://www.someeatery.co.uk', $eatery->website);
+        $this->assertNull($eatery->facebook_url);
+        $this->assertNull($eatery->instagram_url);
+    }
+
+    #[Test]
+    public function itSkipsEateriesWithNoWebsite(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => null,
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertNull($eatery->website);
+        $this->assertNull($eatery->facebook_url);
+        $this->assertNull($eatery->instagram_url);
+    }
+
+    #[Test]
+    public function itSkipsEateriesWithAnEmptyStringWebsite(): void
+    {
+        $eatery = $this->build(Eatery::class)->create([
+            'website' => '',
+        ]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame('', $eatery->website);
+        $this->assertNull($eatery->facebook_url);
+        $this->assertNull($eatery->instagram_url);
+    }
+
+    #[Test]
+    public function itReportsTheCorrectFacebookMigrationCount(): void
+    {
+        $this->build(Eatery::class)->count(3)->create(['website' => 'https://www.facebook.com/eatery']);
+        $this->build(Eatery::class)->count(2)->create(['website' => 'https://fb.com/eatery']);
+        $this->build(Eatery::class)->count(2)->create(['website' => 'https://www.instagram.com/eatery']);
+        $this->build(Eatery::class)->create(['website' => 'https://www.someeatery.co.uk']);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)
+            ->expectsOutputToContain('Facebook URLs migrated: 5')
+            ->run();
+    }
+
+    #[Test]
+    public function itReportsTheCorrectInstagramMigrationCount(): void
+    {
+        $this->build(Eatery::class)->count(3)->create(['website' => 'https://www.facebook.com/eatery']);
+        $this->build(Eatery::class)->count(2)->create(['website' => 'https://www.instagram.com/eatery']);
+        $this->build(Eatery::class)->create(['website' => 'https://www.someeatery.co.uk']);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)
+            ->expectsOutputToContain('Instagram URLs migrated: 2')
+            ->run();
+    }
+
+    #[Test]
+    public function itProcessesAllEateriesInASingleRun(): void
+    {
+        $facebook = $this->build(Eatery::class)->create(['website' => 'https://www.facebook.com/fb-eatery']);
+        $instagram = $this->build(Eatery::class)->create(['website' => 'https://www.instagram.com/ig-eatery']);
+        $plain = $this->build(Eatery::class)->create(['website' => 'https://www.plainsite.co.uk']);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $facebook->refresh();
+        $instagram->refresh();
+        $plain->refresh();
+
+        $this->assertSame('https://www.facebook.com/fb-eatery', $facebook->facebook_url);
+        $this->assertNull($facebook->website);
+
+        $this->assertSame('https://www.instagram.com/ig-eatery', $instagram->instagram_url);
+        $this->assertNull($instagram->website);
+
+        $this->assertSame('https://www.plainsite.co.uk', $plain->website);
+        $this->assertNull($plain->facebook_url);
+        $this->assertNull($plain->instagram_url);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function facebookUrlProvider(): array
+    {
+        return [
+            'full facebook.com URL' => ['https://www.facebook.com/eatery'],
+            'facebook.com without www' => ['https://facebook.com/eatery'],
+            'fb.com short URL' => ['https://fb.com/eatery'],
+            'm.facebook.com mobile URL' => ['https://m.facebook.com/eatery'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('facebookUrlProvider')]
+    public function itDetectsVariousFacebookUrlFormats(string $url): void
+    {
+        $eatery = $this->build(Eatery::class)->create(['website' => $url]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame($url, $eatery->facebook_url);
+        $this->assertNull($eatery->website);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function instagramUrlProvider(): array
+    {
+        return [
+            'full instagram.com URL' => ['https://www.instagram.com/eatery'],
+            'instagram.com without www' => ['https://instagram.com/eatery'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('instagramUrlProvider')]
+    public function itDetectsVariousInstagramUrlFormats(string $url): void
+    {
+        $eatery = $this->build(Eatery::class)->create(['website' => $url]);
+
+        $this->artisan(MigrateEateriesSocialUrlsCommand::class)->run();
+
+        $eatery->refresh();
+
+        $this->assertSame($url, $eatery->instagram_url);
+        $this->assertNull($eatery->website);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Changes for https://github.com/coeliacsanctuary/coeliacsanctuary.co.uk/issues/333

Adds dedicated `facebook_url` and `instagram_url` columns to the `wheretoeat` table so social URLs can be stored and displayed distinctly from a traditional website URL.

- Migration adding `facebook_url` and `instagram_url` (varchar 255, nullable) to `wheretoeat`
- Nova `Eateries` resource updated with two new URL fields in the Contact Details panel
- All API resources updated to expose the new fields (`EateryBrowseDetailsResource`, `EateryDetailsResource`, `EateryAppResource`, and all four `Api/V1` eatery resources)
- TypeScript types updated on `NationwideEatery` and `TownEatery` (which `DetailedEatery` extends)
- `EateryHeaderLinks.vue` renders Facebook and Instagram links using existing `FacebookIcon`/`InstagramIcon` components
- `PlaceDetails.vue` (browse map sidebar) falls through `website` → `facebook_url` → `instagram_url` in priority order, displaying whichever is set first
- One-time Artisan command `one-time:migrate-eateries-social-urls` to detect and migrate existing social URLs out of the `website` column, using `updateQuietly` to bypass model events

## Related Issues

Fixes #333

## Deployment Notes

After deploying, run `php artisan one-time:migrate-eateries-social-urls` once to migrate existing social URLs from the `website` column into the new dedicated columns.