### PR TITLE
Promote 'Special Feature' filter above Venue Category and Venue Type in eating out sidebars

### DIFF
--- a/resources/js/Components/PageSpecific/EatingOut/Collections/EateryCollectionFilterSidebarContent.vue
+++ b/resources/js/Components/PageSpecific/EatingOut/Collections/EateryCollectionFilterSidebarContent.vue
@@ -124,6 +124,17 @@ const resetFilters = () => {
     </div>
 
     <div
+      v-if="featureFilters.length > 1"
+      class="px-3"
+    >
+      <FormCheckboxGroup
+        v-model="featureFilters"
+        label="Special Feature"
+        @change="filtersChanged"
+      />
+    </div>
+
+    <div
       v-if="eateryTypeFilters.length > 1"
       class="px-3"
     >
@@ -141,17 +152,6 @@ const resetFilters = () => {
       <FormCheckboxGroup
         v-model="venueTypeFilters"
         label="Venue Type"
-        @change="filtersChanged"
-      />
-    </div>
-
-    <div
-      v-if="featureFilters.length > 1"
-      class="px-3"
-    >
-      <FormCheckboxGroup
-        v-model="featureFilters"
-        label="Special Feature"
         @change="filtersChanged"
       />
     </div>

--- a/resources/js/Components/PageSpecific/EatingOut/Town/TownFilterSidebarContent.vue
+++ b/resources/js/Components/PageSpecific/EatingOut/Town/TownFilterSidebarContent.vue
@@ -78,6 +78,14 @@ const resetFilters = () => {
 
     <div class="px-3">
       <FormCheckboxGroup
+        v-model="featureFilters"
+        label="Special Feature"
+        @change="filtersChanged"
+      />
+    </div>
+
+    <div class="px-3">
+      <FormCheckboxGroup
         v-model="eateryTypeFilters"
         label="Venue Category"
         @change="filtersChanged"
@@ -88,14 +96,6 @@ const resetFilters = () => {
       <FormCheckboxGroup
         v-model="venueTypeFilters"
         label="Venue Type"
-        @change="filtersChanged"
-      />
-    </div>
-
-    <div class="px-3">
-      <FormCheckboxGroup
-        v-model="featureFilters"
-        label="Special Feature"
         @change="filtersChanged"
       />
     </div>


### PR DESCRIPTION
# Pull Request

## Description
Changes for task/bug/feature described in https://github.com/coeliacsanctuary/coeliacsanctuary.co.uk/issues/335

Reorders the filter groups in the eating out filter sidebars so that Special Feature is the first and most prominent filter, followed by Venue Category and Venue Type. County and Town location filters remain at the top in the collections sidebar. Pure template reorder — no script logic changed.

## Related Issues

Fixes #335

## Additional Context
Change affects town pages, London area pages, the browse map page (via FilterMap.vue), and eatery collection pages.

## Deployment Notes
No deployment steps required.