### PR TITLE
Add header image alt text field to blogs, recipes, and collections

### DIFF
--- a/app/Nova/Resources/Main/Blog.php
+++ b/app/Nova/Resources/Main/Blog.php
@@ -120,6 +120,12 @@ class Blog extends Resource
                     ->addButtonLabel('Select Header Image')
                     ->rules(['required']),
 
+                Text::make('Header Image Alt Text', 'header_image_alt_text')
+                    ->nullable()
+                    ->onlyOnForms()
+                    ->fullWidth()
+                    ->help('Descriptive alt text for the header image. Defaults to the blog title if left blank.'),
+
                 Images::make('Social Image', 'social')
                     ->onlyOnForms()
                     ->addButtonLabel('Select Social Image')

--- a/app/Nova/Resources/Main/Collection.php
+++ b/app/Nova/Resources/Main/Collection.php
@@ -118,6 +118,12 @@ class Collection extends Resource
                     ->addButtonLabel('Select Header Image')
                     ->rules(['required']),
 
+                Text::make('Header Image Alt Text', 'header_image_alt_text')
+                    ->nullable()
+                    ->onlyOnForms()
+                    ->fullWidth()
+                    ->help('Descriptive alt text for the header image. Defaults to the collection title if left blank.'),
+
                 Images::make('Social Image', 'social')
                     ->onlyOnForms()
                     ->addButtonLabel('Select Social Image')

--- a/app/Nova/Resources/Main/Recipe.php
+++ b/app/Nova/Resources/Main/Recipe.php
@@ -85,6 +85,12 @@ class Recipe extends Resource
                     ->addButtonLabel('Select Header Image')
                     ->rules(['required']),
 
+                Text::make('Header Image Alt Text', 'header_image_alt_text')
+                    ->nullable()
+                    ->onlyOnForms()
+                    ->fullWidth()
+                    ->help('Descriptive alt text for the header image. Defaults to the recipe title if left blank.'),
+
                 Images::make('Square Image', 'square')
                     ->onlyOnForms()
                     ->addButtonLabel('Select Square Image')

--- a/app/Resources/Blogs/BlogDetailCardViewResource.php
+++ b/app/Resources/Blogs/BlogDetailCardViewResource.php
@@ -21,6 +21,7 @@ class BlogDetailCardViewResource extends JsonResource
             'title' => Str::of($this->title)->replace('&quot;', '"'),
             'link' => $this->link,
             'image' => $this->main_image_as_webp ?? $this->main_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
             'date' => $this->published,
             'description' => $this->meta_description,
             'comments_count' => $this->comments_count,

--- a/app/Resources/Blogs/BlogShowResource.php
+++ b/app/Resources/Blogs/BlogShowResource.php
@@ -41,6 +41,7 @@ class BlogShowResource extends JsonResource
                     ],
                 ]),
             'hasTwitterEmbed' => Str::contains($this->body, $twitterReplacements),
+            'header_image_alt_text' => $this->header_image_alt_text,
             'show_author' => $this->show_author,
             'tags' => new BlogTagCollection($this->tags),
             'featured_in' => FeaturedInCollectionSimpleCardViewResource::collection($this->associatedCollectionGroups),

--- a/app/Resources/Blogs/BlogSimpleCardViewResource.php
+++ b/app/Resources/Blogs/BlogSimpleCardViewResource.php
@@ -20,6 +20,7 @@ class BlogSimpleCardViewResource extends JsonResource
             'title' => Str::of($this->title)->replace('&quot;', '"'),
             'link' => $this->link,
             'image' => $this->main_image_as_webp ?? $this->main_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
         ];
     }
 }

--- a/app/Resources/Collections/CollectedItemSimpleCardViewResource.php
+++ b/app/Resources/Collections/CollectedItemSimpleCardViewResource.php
@@ -26,6 +26,7 @@ class CollectedItemSimpleCardViewResource extends JsonResource
             'title' => $item->title,
             'link' => $item->link,
             'image' => $item->main_image_as_webp ?? $item->main_image,
+            'header_image_alt_text' => $item->header_image_alt_text,
             'square_image' => $item->square_image_as_webp ?? $item->square_image,
         ];
     }

--- a/app/Resources/Collections/CollectionDetailCardViewResource.php
+++ b/app/Resources/Collections/CollectionDetailCardViewResource.php
@@ -18,6 +18,7 @@ class CollectionDetailCardViewResource extends JsonResource
             'title' => $this->title,
             'link' => $this->link,
             'image' => $this->main_image_as_wepb ?? $this->main_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
             'date' => $this->lastUpdated,
             'description' => $this->meta_description,
             'number_of_items' => $this->groups->sum('items_count'),

--- a/app/Resources/Collections/CollectionGroupItemResource.php
+++ b/app/Resources/Collections/CollectionGroupItemResource.php
@@ -47,6 +47,7 @@ class CollectionGroupItemResource extends JsonResource
             'title' => $this->item_title ?? $blog->title,
             'description' => $this->item_description ?? $blog->meta_description,
             'image' => $blog->main_image_as_webp ?? $blog->main_image,
+            'header_image_alt_text' => $blog->header_image_alt_text,
             'date' => $blog->lastUpdated,
             'link' => $blog->link,
         ];
@@ -58,6 +59,7 @@ class CollectionGroupItemResource extends JsonResource
             'title' => $this->item_title ?? $recipe->title,
             'description' => $this->item_description ?? $recipe->meta_description,
             'image' => $recipe->main_image_as_webp ?? $recipe->main_image,
+            'header_image_alt_text' => $recipe->header_image_alt_text,
             'square_image' => $recipe->square_image_as_webp ?? $recipe->square_image,
             'date' => $recipe->lastUpdated,
             'link' => $recipe->link,

--- a/app/Resources/Collections/CollectionShowResource.php
+++ b/app/Resources/Collections/CollectionShowResource.php
@@ -18,6 +18,7 @@ class CollectionShowResource extends JsonResource
             'id' => $this->id,
             'title' => $this->title,
             'image' => $this->main_image_as_webp ?? $this->main_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
             'published' => $this->published,
             'updated' => $this->lastUpdated,
             'description' => $this->description,

--- a/app/Resources/Collections/FeaturedInCollectionSimpleCardViewResource.php
+++ b/app/Resources/Collections/FeaturedInCollectionSimpleCardViewResource.php
@@ -22,6 +22,7 @@ class FeaturedInCollectionSimpleCardViewResource extends JsonResource
             'title' => $collection->title,
             'link' => route('collection.show', ['collection' => $collection]),
             'image' => $collection->main_image_as_webp ?? $collection->main_image,
+            'header_image_alt_text' => $collection->header_image_alt_text,
             'description' => $collection->meta_description,
         ];
     }

--- a/app/Resources/Recipes/RecipeDetailCardViewResource.php
+++ b/app/Resources/Recipes/RecipeDetailCardViewResource.php
@@ -23,6 +23,7 @@ class RecipeDetailCardViewResource extends JsonResource
             'title' => $this->title,
             'link' => $this->link,
             'image' => $this->main_image_as_webp ?? $this->main_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
             'square_image' => $this->square_image_as_webp ?? $this->square_image,
             'date' => $this->published,
             'description' => $this->meta_description,

--- a/app/Resources/Recipes/RecipeShowResource.php
+++ b/app/Resources/Recipes/RecipeShowResource.php
@@ -29,6 +29,7 @@ class RecipeShowResource extends JsonResource
             'id' => $this->id,
             'print_url' => route('recipe.print', ['recipe' => $this]),
             'title' => $this->title,
+            'header_image_alt_text' => $this->header_image_alt_text,
             'short_title' => $this->short_title,
             'image' => $this->main_image_as_webp ?? $this->main_image,
             'square_image' => $this->square_image_as_webp ?? $this->square_image,

--- a/app/Resources/Recipes/RecipeSimpleCardViewResource.php
+++ b/app/Resources/Recipes/RecipeSimpleCardViewResource.php
@@ -18,6 +18,7 @@ class RecipeSimpleCardViewResource extends JsonResource
             'title' => $this->title,
             'link' => $this->link,
             'image' => $this->square_image_as_webp ?? $this->square_image,
+            'header_image_alt_text' => $this->header_image_alt_text,
         ];
     }
 }

--- a/database/migrations/2026_06_02_162852_add_header_image_alt_text_to_blogs_table.php
+++ b/database/migrations/2026_06_02_162852_add_header_image_alt_text_to_blogs_table.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('blogs', function (Blueprint $table): void {
+            $table->string('header_image_alt_text')->nullable()->after('body');
+        });
+    }
+};

--- a/database/migrations/2026_06_02_162853_add_header_image_alt_text_to_collections_table.php
+++ b/database/migrations/2026_06_02_162853_add_header_image_alt_text_to_collections_table.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('collections', function (Blueprint $table): void {
+            $table->string('header_image_alt_text')->nullable()->after('body');
+        });
+    }
+};

--- a/database/migrations/2026_06_02_162853_add_header_image_alt_text_to_recipes_table.php
+++ b/database/migrations/2026_06_02_162853_add_header_image_alt_text_to_recipes_table.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('recipes', function (Blueprint $table): void {
+            $table->string('header_image_alt_text')->nullable()->after('body');
+        });
+    }
+};

--- a/resources/js/Components/PageSpecific/Blogs/BlogDetailCard.vue
+++ b/resources/js/Components/PageSpecific/Blogs/BlogDetailCard.vue
@@ -26,7 +26,7 @@ useJourneyTracking().logWhenVisible(
         prefetch
       >
         <img
-          :alt="blog.title"
+          :alt="blog.header_image_alt_text ?? blog.title"
           :src="blog.image"
           loading="lazy"
         />

--- a/resources/js/Components/PageSpecific/Blogs/BlogSimpleCard.vue
+++ b/resources/js/Components/PageSpecific/Blogs/BlogSimpleCard.vue
@@ -19,7 +19,7 @@ withDefaults(defineProps<{ blog: BlogSimpleCard; hover?: boolean }>(), {
       class="group -m-4"
     >
       <img
-        :alt="blog.title"
+        :alt="blog.header_image_alt_text ?? blog.title"
         :src="blog.image"
         loading="lazy"
       />

--- a/resources/js/Components/PageSpecific/Collections/CollectionDetailCard.vue
+++ b/resources/js/Components/PageSpecific/Collections/CollectionDetailCard.vue
@@ -26,7 +26,7 @@ useJourneyTracking().logWhenVisible(
         prefetch
       >
         <img
-          :alt="collection.title"
+          :alt="collection.header_image_alt_text ?? collection.title"
           :src="collection.image"
           loading="lazy"
         />

--- a/resources/js/Components/PageSpecific/Collections/Items/BlogCollectionItem.vue
+++ b/resources/js/Components/PageSpecific/Collections/Items/BlogCollectionItem.vue
@@ -18,7 +18,7 @@ defineProps<{ item: BlogCollectionItem }>();
         prefetch
       >
         <img
-          :alt="item.title"
+          :alt="item.header_image_alt_text ?? item.title"
           :src="item.image"
           loading="lazy"
         />

--- a/resources/js/Components/PageSpecific/Collections/Items/RecipeCollectionItem.vue
+++ b/resources/js/Components/PageSpecific/Collections/Items/RecipeCollectionItem.vue
@@ -20,13 +20,13 @@ defineProps<{ item: RecipeCollectionItem }>();
       >
         <img
           v-if="item.square_image"
-          :alt="item.title"
+          :alt="item.header_image_alt_text ?? item.title"
           :src="item.image"
           loading="lazy"
         />
         <RecipeSquareImage
           v-else
-          :alt="item.title"
+          :alt="item.header_image_alt_text ?? item.title"
           :src="item.image"
         />
       </Link>

--- a/resources/js/Components/PageSpecific/Home/HomeHoverItem.vue
+++ b/resources/js/Components/PageSpecific/Home/HomeHoverItem.vue
@@ -23,13 +23,13 @@ defineProps<{ item: HomeHoverItemType }>();
             item.type !== 'Recipe' ||
             (item.type === 'Recipe' && item.square_image)
           "
-          :alt="item.title"
+          :alt="item.header_image_alt_text ?? item.title"
           :src="item.image"
           loading="lazy"
         />
         <RecipeSquareImage
           v-else
-          :alt="item.title"
+          :alt="item.header_image_alt_text ?? item.title"
           :src="item.image"
         />
 

--- a/resources/js/Components/PageSpecific/Recipes/RecipeDetailCard.vue
+++ b/resources/js/Components/PageSpecific/Recipes/RecipeDetailCard.vue
@@ -28,13 +28,13 @@ useJourneyTracking().logWhenVisible(
       >
         <img
           v-if="recipe.square_image"
-          :alt="recipe.title"
+          :alt="recipe.header_image_alt_text ?? recipe.title"
           :src="recipe.image"
           loading="lazy"
         />
         <RecipeSquareImage
           v-else
-          :alt="recipe.title"
+          :alt="recipe.header_image_alt_text ?? recipe.title"
           :src="recipe.image"
         />
       </Link>

--- a/resources/js/Components/PageSpecific/Recipes/RecipeSimpleCard.vue
+++ b/resources/js/Components/PageSpecific/Recipes/RecipeSimpleCard.vue
@@ -16,7 +16,7 @@ defineProps<{ recipe: RecipeDetailCard }>();
       class="group -m-4"
     >
       <img
-        :alt="recipe.title"
+        :alt="recipe.header_image_alt_text ?? recipe.title"
         :src="recipe.image"
         loading="lazy"
       />

--- a/resources/js/Components/PageSpecific/Shared/FeaturedInCollectionCard.vue
+++ b/resources/js/Components/PageSpecific/Shared/FeaturedInCollectionCard.vue
@@ -28,7 +28,7 @@ defineProps<{ collections: FeaturedInCollection[]; title: string }>();
       <Link :href="collection.link">
         <img
           :src="collection.image"
-          :alt="collection.title"
+          :alt="collection.header_image_alt_text ?? collection.title"
           class="scale-95 transform transition duration-500 group-hover:scale-100 group-hover:opacity-100 sm:opacity-80"
         />
       </Link>

--- a/resources/js/Pages/Blog/Preview.vue
+++ b/resources/js/Pages/Blog/Preview.vue
@@ -59,7 +59,7 @@ onMounted(() => {
     no-padding
   >
     <img
-      :alt="blog.title"
+      :alt="blog.header_image_alt_text ?? blog.title"
       :src="blog.image"
       loading="lazy"
     />

--- a/resources/js/Pages/Blog/Show.vue
+++ b/resources/js/Pages/Blog/Show.vue
@@ -139,7 +139,7 @@ const groupedRelatedBlogs = computed<GroupedBlogs[]>(() => {
 
   <Card no-padding>
     <img
-      :alt="blog.title"
+      :alt="blog.header_image_alt_text ?? blog.title"
       :src="blog.image"
       loading="lazy"
     />

--- a/resources/js/Pages/Collection/Show.vue
+++ b/resources/js/Pages/Collection/Show.vue
@@ -33,7 +33,7 @@ defineProps<{ collection: CollectionPage }>();
 
   <Card no-padding>
     <img
-      :alt="collection.title"
+      :alt="collection.header_image_alt_text ?? collection.title"
       :src="collection.image"
       loading="lazy"
     />

--- a/resources/js/Pages/Recipe/Show.vue
+++ b/resources/js/Pages/Recipe/Show.vue
@@ -200,13 +200,13 @@ const handleCommentReset = () => {
   <Card no-padding>
     <img
       v-if="recipe.square_image"
-      :alt="recipe.title"
+      :alt="recipe.header_image_alt_text ?? recipe.title"
       :src="recipe.image"
       loading="lazy"
     />
     <RecipeSquareImage
       v-else
-      :alt="recipe.title"
+      :alt="recipe.header_image_alt_text ?? recipe.title"
       :src="recipe.image"
     />
   </Card>

--- a/resources/js/types/BlogTypes.d.ts
+++ b/resources/js/types/BlogTypes.d.ts
@@ -19,6 +19,7 @@ export type BlogPage = {
   id: number;
   title: string;
   image: string;
+  header_image_alt_text?: string;
   published: string;
   updated: string | null;
   description: string;

--- a/resources/js/types/CollectionTypes.d.ts
+++ b/resources/js/types/CollectionTypes.d.ts
@@ -11,6 +11,7 @@ export type CollectionPage = {
   id: number;
   title: string;
   image: string;
+  header_image_alt_text?: string;
   published: string;
   updated: string;
   author: string;
@@ -39,6 +40,7 @@ export type BlogCollectionItem = CollectionItem & {
   description: string;
   date: string;
   image: string;
+  header_image_alt_text?: string;
 };
 
 export type RecipeCollectionItem = CollectionItem & {
@@ -47,6 +49,7 @@ export type RecipeCollectionItem = CollectionItem & {
   description: string;
   date: string;
   image: string;
+  header_image_alt_text?: string;
   square_image?: string;
 };
 
@@ -74,6 +77,7 @@ export type HomepageCollectedItem = {
   type: 'Blog' | 'Recipe';
   title: string;
   image: string;
+  header_image_alt_text?: string;
   square_image?: string;
   link: string;
 };
@@ -83,4 +87,5 @@ export type FeaturedInCollection = {
   link: string;
   description: string;
   image: string;
+  header_image_alt_text?: string;
 };

--- a/resources/js/types/RecipeTypes.d.ts
+++ b/resources/js/types/RecipeTypes.d.ts
@@ -17,6 +17,7 @@ export type RecipePage = {
   id: number;
   print_url: string;
   title: string;
+  header_image_alt_text?: string;
   short_title?: string;
   image: string;
   square_image: string;

--- a/resources/js/types/Types.d.ts
+++ b/resources/js/types/Types.d.ts
@@ -10,6 +10,7 @@ export type HomeHoverItem = {
   title: string;
   link: string;
   image: string;
+  header_image_alt_text?: string;
   square_image?: string;
   type?: 'Blog' | 'Recipe';
 };

--- a/tests/Feature/Http/Controllers/Blogs/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Blogs/IndexControllerTest.php
@@ -72,7 +72,7 @@ class IndexControllerTest extends TestCase
                         'blogs.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'link', 'description', 'tags', 'comments_count'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'description', 'tags', 'comments_count'])
                     )
                     ->where('blogs.data.0.title', 'Blog 0')
                     ->where('blogs.data.1.title', 'Blog 1')
@@ -97,7 +97,7 @@ class IndexControllerTest extends TestCase
                         'blogs.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'link', 'description', 'tags', 'comments_count'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'description', 'tags', 'comments_count'])
                     )
                     ->where('blogs.data.0.title', 'Blog 12')
                     ->where('blogs.data.1.title', 'Blog 13')
@@ -165,7 +165,7 @@ class IndexControllerTest extends TestCase
                 fn (Assert $page) => $page
                     ->component('Blog/Index')
                     ->has('blogs')
-                    ->has('blogs.data', 2, fn (Assert $page) => $page->hasAll(['title', 'description', 'date', 'image', 'link', 'description', 'tags', 'comments_count']))
+                    ->has('blogs.data', 2, fn (Assert $page) => $page->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'description', 'tags', 'comments_count']))
                     ->where('blogs.data.0.title', 'Blog 0')
                     ->has('blogs.links')
                     ->has('blogs.meta')
@@ -194,7 +194,7 @@ class IndexControllerTest extends TestCase
                         'blogs.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'link', 'description', 'tags', 'comments_count'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'description', 'tags', 'comments_count'])
                     )
                     ->where('blogs.data.0.title', 'Blog 12')
                     ->where('blogs.data.1.title', 'Blog 13')

--- a/tests/Feature/Http/Controllers/Collections/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Collections/IndexControllerTest.php
@@ -57,7 +57,7 @@ class IndexControllerTest extends TestCase
                     ->has(
                         'collections.data',
                         12,
-                        fn (Assert $page) => $page->hasAll(['title', 'description', 'date', 'image', 'link', 'number_of_items'])
+                        fn (Assert $page) => $page->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'number_of_items'])
                     )
                     ->where('collections.data.0.title', 'Collection 0')
                     ->where('collections.data.1.title', 'Collection 1')
@@ -82,7 +82,7 @@ class IndexControllerTest extends TestCase
                         'collections.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'link', 'number_of_items'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'link', 'number_of_items'])
                     )
                     ->where('collections.data.0.title', 'Collection 12')
                     ->where('collections.data.1.title', 'Collection 13')

--- a/tests/Feature/Http/Controllers/HomepageTest.php
+++ b/tests/Feature/Http/Controllers/HomepageTest.php
@@ -85,7 +85,7 @@ class HomepageTest extends TestCase
                         'blogs',
                         6,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'image', 'link'])
+                            ->hasAll(['title', 'image', 'header_image_alt_text', 'link'])
                     )
                     ->where('blogs.0.title', 'Blog 0')
                     ->where('blogs.1.title', 'Blog 1')
@@ -105,7 +105,7 @@ class HomepageTest extends TestCase
                         'blogs',
                         6,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'image', 'link'])
+                            ->hasAll(['title', 'image', 'header_image_alt_text', 'link'])
                     )
                     ->where('blogs.0.title', 'Blog 1')
                     ->where('blogs.1.title', 'Blog 2')
@@ -125,7 +125,7 @@ class HomepageTest extends TestCase
                         'recipes',
                         8,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'image', 'link'])
+                            ->hasAll(['title', 'image', 'header_image_alt_text', 'link'])
                     )
                     ->where('recipes.0.title', 'Recipe 0')
                     ->where('recipes.1.title', 'Recipe 1')
@@ -145,7 +145,7 @@ class HomepageTest extends TestCase
                         'recipes',
                         8,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'image', 'link'])
+                            ->hasAll(['title', 'image', 'header_image_alt_text', 'link'])
                     )
                     ->where('recipes.0.title', 'Recipe 1')
                     ->where('recipes.1.title', 'Recipe 2')

--- a/tests/Feature/Http/Controllers/Recipes/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Recipes/IndexControllerTest.php
@@ -106,7 +106,7 @@ class IndexControllerTest extends TestCase
                         'recipes.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'square_image', 'link', 'description', 'features', 'nutrition'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'square_image', 'link', 'description', 'features', 'nutrition'])
                     )
                     ->where('recipes.data.0.title', 'Recipe 0')
                     ->where('recipes.data.1.title', 'Recipe 1')
@@ -131,7 +131,7 @@ class IndexControllerTest extends TestCase
                         'recipes.data',
                         12,
                         fn (Assert $page) => $page
-                            ->hasAll(['title', 'description', 'date', 'image', 'square_image', 'link', 'description', 'features', 'nutrition'])
+                            ->hasAll(['title', 'description', 'date', 'image', 'header_image_alt_text', 'square_image', 'link', 'description', 'features', 'nutrition'])
                     )
                     ->where('recipes.data.0.title', 'Recipe 12')
                     ->where('recipes.data.1.title', 'Recipe 13')


### PR DESCRIPTION
## Description

Adds a nullable `header_image_alt_text` column to the `blogs`, `recipes`, and `collections` tables, surfaces it in Nova, and uses it across all frontend components that render header/primary images — falling back to the item title when not set.

## Related Issues

Fixes #361