### PR TITLE
Add FAQ support to blogs

### DIFF
--- a/app/Models/Blogs/Blog.php
+++ b/app/Models/Blogs/Blog.php
@@ -54,6 +54,10 @@ class Blog extends Model implements Collectable, HasComments, HasMedia, IsSearch
     use LinkableModel;
     use Searchable;
 
+    protected $casts = [
+        'faqs' => 'array',
+    ];
+
     protected static function booted(): void
     {
         static::addGlobalScope(new LiveScope());

--- a/app/Nova/Repeaters/ArticleFaq.php
+++ b/app/Nova/Repeaters/ArticleFaq.php
@@ -9,7 +9,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
-class RecipeFaq extends Repeatable
+class ArticleFaq extends Repeatable
 {
     /**
      * Get the fields displayed by the repeatable.

--- a/app/Nova/Resources/Main/Blog.php
+++ b/app/Nova/Resources/Main/Blog.php
@@ -6,6 +6,7 @@ namespace App\Nova\Resources\Main;
 
 use App\Models\Blogs\Blog as BlogModel;
 use App\Nova\Chartables\Metrics\Blogs\CollectionCardViews;
+use App\Nova\Repeaters\ArticleFaq;
 use App\Nova\Chartables\Metrics\Blogs\CommentViews;
 use App\Nova\Chartables\Metrics\Blogs\DetailCardViews;
 use App\Nova\Chartables\Metrics\Blogs\Views;
@@ -23,6 +24,7 @@ use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\FormData;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphMany;
+use Laravel\Nova\Fields\Repeater;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Tag;
@@ -59,6 +61,13 @@ class Blog extends Resource
 
             new Panel('Introduction', [
                 Text::make('Title')->fullWidth()->rules(['required', 'max:200'])->showWhenPeeking(),
+
+                Text::make('Short Title')
+                    ->fullWidth()
+                    ->maxlength(100)
+                    ->onlyOnForms()
+                    ->help('Optional, used with FAQs')
+                    ->nullable(),
 
                 Slug::make('Slug')->from('Title')
                     ->hideFromIndex()
@@ -151,6 +160,16 @@ class Blog extends Resource
                     ->help('If checked, the about Alison block will be shown at the bottom of the blog.'),
 
                 PreviewButton::make('Preview')->forModel('blog')->onlyOnForms(),
+            ]),
+
+            new Panel('FAQ', [
+                Repeater::make('FAQs', 'faqs')
+                    ->asJson()
+                    ->repeatables([ArticleFaq::make()]),
+
+                Select::make('Display FAQ', 'faq_display')
+                    ->options(['top' => 'Above content', 'bottom' => 'Below content'])
+                    ->nullable(),
             ]),
 
             DateTime::make('Created At')->sortable()->exceptOnForms(),

--- a/app/Nova/Resources/Main/Recipe.php
+++ b/app/Nova/Resources/Main/Recipe.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Nova\Resources\Main;
 
 use App\Models\Recipes\Recipe as RecipeModel;
-use App\Nova\Repeaters\RecipeFaq;
+use App\Nova\Repeaters\ArticleFaq;
 use App\Nova\Resource;
 use App\Nova\Resources\Main\PolymorphicPanels\RecipeAllergens as RecipeAllergenPanel;
 use App\Nova\Resources\Main\PolymorphicPanels\RecipeFeatures as RecipeFeaturePanel;
@@ -159,7 +159,7 @@ class Recipe extends Resource
             Repeater::make('FAQs', 'faqs')
                 ->asJson()
                 ->repeatables([
-                    RecipeFaq::make(),
+                    ArticleFaq::make(),
                 ]),
 
             DateTime::make('Created At')->sortable()->exceptOnForms(),

--- a/app/Resources/Blogs/BlogShowResource.php
+++ b/app/Resources/Blogs/BlogShowResource.php
@@ -9,6 +9,7 @@ use App\ResourceCollections\Blogs\BlogTagCollection;
 use App\Resources\Collections\FeaturedInCollectionSimpleCardViewResource;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 
@@ -42,9 +43,21 @@ class BlogShowResource extends JsonResource
                 ]),
             'hasTwitterEmbed' => Str::contains($this->body, $twitterReplacements),
             'header_image_alt_text' => $this->header_image_alt_text,
+            'short_title' => $this->short_title,
             'show_author' => $this->show_author,
             'tags' => new BlogTagCollection($this->tags),
             'featured_in' => FeaturedInCollectionSimpleCardViewResource::collection($this->associatedCollectionGroups),
+            'faqs' => $this->faqs ? $this->parseFaqs($this->faqs) : null,
+            'faq_display' => $this->faq_display,
         ];
+    }
+
+    /**
+     * @param  array<int, array{fields: array{question: string, answer: string}}>  $faqs
+     * @return Collection<int, array{question: string, answer: string}>
+     */
+    protected function parseFaqs(array $faqs): Collection
+    {
+        return collect($faqs)->map(fn ($faq) => $faq['fields']);
     }
 }

--- a/database/migrations/2026_06_02_172729_add_faq_columns_to_blogs_table.php
+++ b/database/migrations/2026_06_02_172729_add_faq_columns_to_blogs_table.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('blogs', function (Blueprint $table): void {
+            $table->string('short_title')->nullable()->after('title');
+            $table->json('faqs')->nullable()->after('body');
+            $table->string('faq_display')->nullable()->after('faqs');
+        });
+    }
+};

--- a/resources/js/Components/PageSpecific/Shared/ArticleFaqCard.vue
+++ b/resources/js/Components/PageSpecific/Shared/ArticleFaqCard.vue
@@ -1,0 +1,36 @@
+<script lang="ts" setup>
+import Card from '@/Components/Card.vue';
+import SubHeading from '@/Components/SubHeading.vue';
+import { ArticleFaq } from '@/types/Types';
+
+defineProps<{
+  faqs: ArticleFaq[];
+  title: string;
+}>();
+</script>
+
+<template>
+  <Card>
+    <SubHeading classes="text-primary-dark">
+      {{ title }}
+    </SubHeading>
+
+    <div
+      v-for="faq in faqs"
+      :key="faq.question"
+      class="mt-3 divide-y divide-primary"
+    >
+      <div class="flex flex-col space-y-3">
+        <h3
+          class="text-xl font-semibold md:text-2xl"
+          v-text="faq.question"
+        />
+
+        <p
+          class="prose prose-lg max-w-none md:prose-xl"
+          v-html="faq.answer"
+        />
+      </div>
+    </div>
+  </Card>
+</template>

--- a/resources/js/Pages/Blog/Show.vue
+++ b/resources/js/Pages/Blog/Show.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import ArticleFaqCard from '@/Components/PageSpecific/Shared/ArticleFaqCard.vue';
 import Card from '@/Components/Card.vue';
 import Heading from '@/Components/Heading.vue';
 import { Link, router } from '@inertiajs/vue3';
@@ -145,6 +146,12 @@ const groupedRelatedBlogs = computed<GroupedBlogs[]>(() => {
     />
   </Card>
 
+  <ArticleFaqCard
+    v-if="blog.faqs && blog.faq_display === 'top'"
+    :faqs="blog.faqs"
+    :title="`Frequently asked questions about ${blog.short_title || blog.title}`"
+  />
+
   <div
     class="flex w-full flex-col space-y-3 lg:flex-row lg:space-y-0 lg:space-x-3"
   >
@@ -154,6 +161,12 @@ const groupedRelatedBlogs = computed<GroupedBlogs[]>(() => {
           <RenderedString :content="blog.body" />
         </div>
       </Card>
+
+      <ArticleFaqCard
+        v-if="blog.faqs && (!blog.faq_display || blog.faq_display === 'bottom')"
+        :faqs="blog.faqs"
+        :title="`Frequently asked questions about ${blog.short_title || blog.title}`"
+      />
 
       <Card
         v-if="blog.show_author"

--- a/resources/js/Pages/Recipe/Show.vue
+++ b/resources/js/Pages/Recipe/Show.vue
@@ -10,6 +10,7 @@ import { PrinterIcon } from '@heroicons/vue/20/solid';
 import RecipeSquareImage from '@/Components/PageSpecific/Recipes/RecipeSquareImage.vue';
 import RecipeNutritionTable from '@/Components/PageSpecific/Recipes/RecipeNutritionTable.vue';
 import { Page } from '@inertiajs/core';
+import ArticleFaqCard from '@/Components/PageSpecific/Shared/ArticleFaqCard.vue';
 import SubHeading from '@/Components/SubHeading.vue';
 import Warning from '@/Components/Warning.vue';
 import Info from '@/Components/Info.vue';
@@ -217,29 +218,11 @@ const handleCommentReset = () => {
     </div>
   </Card>
 
-  <Card v-if="recipe.faqs">
-    <SubHeading classes="text-primary-dark">
-      Here are some tips and FAQs about {{ recipe.short_title || recipe.title }}
-    </SubHeading>
-
-    <div
-      v-for="faq in recipe.faqs"
-      :key="faq.question"
-      class="mt-3 divide-y divide-primary"
-    >
-      <div class="flex flex-col space-y-3">
-        <h3
-          class="text-xl font-semibold md:text-2xl"
-          v-text="faq.question"
-        />
-
-        <p
-          class="prose prose-lg max-w-none md:prose-xl"
-          v-html="faq.answer"
-        />
-      </div>
-    </div>
-  </Card>
+  <ArticleFaqCard
+    v-if="recipe.faqs"
+    :faqs="recipe.faqs"
+    :title="`Here are some tips and FAQs about ${recipe.short_title || recipe.title}`"
+  />
 
   <div
     ref="recipeElem"

--- a/resources/js/types/BlogTypes.d.ts
+++ b/resources/js/types/BlogTypes.d.ts
@@ -1,4 +1,4 @@
-import { HomeHoverItem } from '@/types/Types';
+import { ArticleFaq, HomeHoverItem } from '@/types/Types';
 import { FeaturedInCollection } from '@/types/CollectionTypes';
 
 export type BlogSimpleCard = Exclude<HomeHoverItem, 'type' & 'square_image'>;
@@ -25,9 +25,12 @@ export type BlogPage = {
   description: string;
   body: string;
   hasTwitterEmbed: boolean;
+  short_title?: string;
   show_author: boolean;
   tags: BlogTag[];
   featured_in?: FeaturedInCollection[];
+  faqs?: ArticleFaq[];
+  faq_display?: 'top' | 'bottom';
 };
 
 export type BlogTag = {

--- a/resources/js/types/RecipeTypes.d.ts
+++ b/resources/js/types/RecipeTypes.d.ts
@@ -1,4 +1,4 @@
-import { HomeHoverItem } from '@/types/Types';
+import { ArticleFaq, HomeHoverItem } from '@/types/Types';
 import { FeaturedInCollection } from '@/types/CollectionTypes';
 
 export type RecipeDetailCard = HomeHoverItem & {
@@ -42,12 +42,7 @@ export type RecipePage = {
     protein: number;
   };
   featured_in?: FeaturedInCollection[];
-  faqs?: RecipeFaq[];
-};
-
-export type RecipeFaq = {
-  question: string;
-  answer: string;
+  faqs?: ArticleFaq[];
 };
 
 export type RecipeFeature = {

--- a/resources/js/types/Types.d.ts
+++ b/resources/js/types/Types.d.ts
@@ -6,6 +6,11 @@ import {
   VNodeProps,
 } from 'vue';
 
+export type ArticleFaq = {
+  question: string;
+  answer: string;
+};
+
 export type HomeHoverItem = {
   title: string;
   link: string;

--- a/tests/Unit/Resources/Blogs/BlogShowResourceTest.php
+++ b/tests/Unit/Resources/Blogs/BlogShowResourceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resources\Blogs;
+
+use App\Models\Blogs\Blog;
+use App\Resources\Blogs\BlogShowResource;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BlogShowResourceTest extends TestCase
+{
+    protected Blog $blog;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withBlogs(1);
+
+        $this->blog = Blog::query()->first();
+    }
+
+    #[Test]
+    public function itReturnsNullFaqsWhenFaqsColumnIsNull(): void
+    {
+        $resource = (new BlogShowResource($this->blog))->toArray(new Request());
+
+        $this->assertNull($resource['faqs']);
+    }
+
+    #[Test]
+    public function itParsesFaqsWhenSet(): void
+    {
+        $this->blog->update([
+            'faqs' => [
+                ['fields' => ['question' => 'Is this gluten free?', 'answer' => 'Yes!']],
+                ['fields' => ['question' => 'Can I freeze it?', 'answer' => 'Absolutely.']],
+            ],
+        ]);
+
+        $resource = (new BlogShowResource($this->blog->fresh()))->toArray(new Request());
+
+        $this->assertCount(2, $resource['faqs']);
+        $this->assertSame('Is this gluten free?', $resource['faqs'][0]['question']);
+        $this->assertSame('Yes!', $resource['faqs'][0]['answer']);
+        $this->assertSame('Can I freeze it?', $resource['faqs'][1]['question']);
+        $this->assertSame('Absolutely.', $resource['faqs'][1]['answer']);
+    }
+
+    #[Test]
+    public function itReturnsShortTitle(): void
+    {
+        $this->blog->update(['short_title' => 'My short title']);
+
+        $resource = (new BlogShowResource($this->blog->fresh()))->toArray(new Request());
+
+        $this->assertSame('My short title', $resource['short_title']);
+    }
+
+    #[Test]
+    public function itReturnsNullShortTitleWhenNotSet(): void
+    {
+        $resource = (new BlogShowResource($this->blog))->toArray(new Request());
+
+        $this->assertNull($resource['short_title']);
+    }
+
+    #[Test]
+    public function itReturnsFaqDisplay(): void
+    {
+        $this->blog->update(['faq_display' => 'top']);
+
+        $resource = (new BlogShowResource($this->blog->fresh()))->toArray(new Request());
+
+        $this->assertSame('top', $resource['faq_display']);
+    }
+
+    #[Test]
+    public function itReturnsNullFaqDisplayWhenNotSet(): void
+    {
+        $resource = (new BlogShowResource($this->blog))->toArray(new Request());
+
+        $this->assertNull($resource['faq_display']);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Ports the existing recipe FAQ feature to blogs. Adds `short_title`, `faqs`, and `faq_display` columns to the `blogs` table. Renames the `RecipeFaq` Nova repeatable to `ArticleFaq` so it can be shared between both resources. Extracts the inline FAQ card from `Recipe/Show.vue` into a reusable `ArticleFaqCard` component, and renders it conditionally in `Blog/Show.vue` above or below content based on `faq_display`, defaulting to bottom when unset.

## Related Issues
Fixes #360